### PR TITLE
Add config for hot reload on mac, ignore modules in image and bindmount

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - .:/app
+      - /app/node_modules # do not bind mount node_modules
     ports:
       - '8082:8080'

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,12 @@
 const { defineConfig } = require("@vue/cli-service");
 module.exports = defineConfig({
   transpileDependencies: true,
+  devServer: {
+    client: {
+      webSocketURL: {
+        hostname: 'localhost',
+        port: 8082
+      },
+    },
+  },
 });


### PR DESCRIPTION
- Added config in the vue.config.js file to allow hot reload in docker for mac
- Ignore node_modules in image
- Bind mount everything in the project directory safe the node_modules