### PR TITLE
Add responsive title swapping

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -94,7 +94,7 @@ export default {
     border-radius: 0 !important;
   }
 
-  img {
+  .left-side img {
     margin-inline-start: 10px;
   }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,7 +7,10 @@ const router = createRouter({
     {
       path: '/',
       name: 'home',
-      component: HomeView
+      component: HomeView,
+      meta: {
+        title: "Home | Toolhunt"
+      }
     },
     {
       path: '/dashboard',
@@ -15,14 +18,26 @@ const router = createRouter({
       // route level code-splitting
       // this generates a separate chunk for this route
       // which is lazy-loaded when the route is visited.
-      component: () => import('../views/DashboardView.vue')
+      component: () => import('../views/DashboardView.vue'),
+      meta: {
+        title: "Dashboard | Toolhunt"
+      }
     },
     {
       path: '/leaderboard',
       name: 'leaderboard',
-      component: () => import('../views/LeaderboardView.vue')
+      component: () => import('../views/LeaderboardView.vue'),
+      meta: {
+        title: "Leaderboard | Toolhunt"
+      }
     }
-  ]
+  ],
 })
+
+router.beforeEach((to) => {
+  if (to.meta.title) {
+    document.title = to.meta.title;
+  }
+});
 
 export default router

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,3 +1,51 @@
 <template>
-  <h1>The dashboard goes here.</h1>
+    <section class="dashboard-header">
+          <img src="src/assets/logo-main.svg" height="100" width="100" alt=""/>
+          <div>
+            <h1>Welcome back, {{ username }}!</h1>
+            <p>
+              Here on the Dashboard, you can view your latest contributions and check out global contributions and statistics about Toolhub and the Toolhunt project.
+            </p>
+          </div>
+    </section>
 </template>
+
+<script>
+  export default {
+    data() {
+      return {
+        username: "NicoleLBee"
+      }
+    }
+  }
+</script>
+
+<style>
+  .dashboard-header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    max-width: 800px;
+    margin-inline: auto;
+  }
+
+  .dashboard-header p {
+    display: none;
+  }
+
+  .dashboard-header img {
+    height: 50px;
+    width: 50px;
+  }
+
+  @media (min-width: 600px) {
+    .dashboard-header p {
+      display: block;
+    }
+
+    .dashboard-header img {
+      height: 100px;
+      width: 100px;
+    }
+  }
+</style>


### PR DESCRIPTION
This hadn't been specifically requested but I had been thinking about it a little, since I liked Toolhub's "Home | Toolhub" and thought that we could do better than plain "Toolhunt."

I found a complicated solution at https://www.digitalocean.com/community/tutorials/vuejs-vue-router-modify-head and then checked the router documentation (https://router.vuejs.org/guide/advanced/meta.html) and realized that it could be achieved in a much simpler way, since we're not dealing with a lot of nested routes.  

However, the complicated solution does show me a way to dynamically add meta tags to each page, if we decide to add some later.