### PR TITLE
Add page title change on routes

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,7 +7,10 @@ const router = createRouter({
     {
       path: '/',
       name: 'home',
-      component: HomeView
+      component: HomeView,
+      meta: {
+        title: "Home | Toolhunt"
+      }
     },
     {
       path: '/dashboard',
@@ -15,14 +18,26 @@ const router = createRouter({
       // route level code-splitting
       // this generates a separate chunk for this route
       // which is lazy-loaded when the route is visited.
-      component: () => import('../views/DashboardView.vue')
+      component: () => import('../views/DashboardView.vue'),
+      meta: {
+        title: "Dashboard | Toolhunt"
+      }
     },
     {
       path: '/leaderboard',
       name: 'leaderboard',
-      component: () => import('../views/LeaderboardView.vue')
+      component: () => import('../views/LeaderboardView.vue'),
+      meta: {
+        title: "Leaderboard | Toolhunt"
+      }
     }
-  ]
+  ],
 })
+
+router.beforeEach((to) => {
+  if (to.meta.title) {
+    document.title = to.meta.title;
+  }
+});
 
 export default router


### PR DESCRIPTION
Trying this again, this time without the unintentional extra commits....

This hadn't been specifically requested but I had been thinking about it a little, since I liked Toolhub's "Home | Toolhub" and thought that we could do better than plain "Toolhunt."

I found a complicated solution at https://www.digitalocean.com/community/tutorials/vuejs-vue-router-modify-head and then checked the router documentation (https://router.vuejs.org/guide/advanced/meta.html) and realized that it could be achieved in a much simpler way, since we're not dealing with a lot of nested routes.  

However, the complicated solution does show me a way to dynamically add meta tags to each page, if we decide to add some later.