### PR TITLE
Tweak: Change transform on mobile menu

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -81,12 +81,12 @@ export default {
     position: absolute;
     top: 64px;
     right: 0;
-    transform: translateX(200px) scale(0);
+    transform: translateX(200px) scaleX(0);
     transition: 0.3s;
   }
 
   .mobile-nav-display {
-    transform: translateX(0) scale(1);
+    transform: translateX(0) scaleX(1);
     transition: 0.3s;
   }
 


### PR DESCRIPTION
I didn't like how my pop-in menu was expanding on two axes and realized that I could fix that by using scaleX rather than scale.  Simple!