### PR TITLE
Add backend services to docker-compose file to connect the Frontend t…

### DIFF
--- a/.env.be.dev
+++ b/.env.be.dev
@@ -1,4 +1,0 @@
-FLASK_APP=app.py
-FLASK_CONFIG=development
-FLASK_DEBUG=1
-DATABASE_URL=mysql://user:mypassword@db:3306/mydatabase

--- a/.env.be.dev
+++ b/.env.be.dev
@@ -1,0 +1,4 @@
+FLASK_APP=app.py
+FLASK_CONFIG=development
+FLASK_DEBUG=1
+DATABASE_URL=mysql://user:mypassword@db:3306/mydatabase

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Frontend Repository for Toolhunt. Toolhunt is a web application for editing Tool
 * Clone the Frontend repository to your machine using `git clone https://github.com/wikimedia/toolhunt-ui.git` 
 * Clone the Backend repository to your machine using `git clone https://github.com/wikimedia/toolhunt.git`
 * CD into the Backend directory and follow the setup instructions in the README
+* Note: The Backend services need to be running before starting the Frontend service
 * CD to the cloned Frontend repository and run this command `docker-compose up -d`
 * Finally, to view the Frontend page on the browser: Naviage to `http://localhost:8082/`
 ## Languages and Tools

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Frontend Repository for Toolhunt. Toolhunt is a web application for editing Tool
 ## Issue Tracker
  This project uses [Phabricator](https://phabricator.wikimedia.org/project/board/6283/) to track issues and we would advice against using Github issue traking for bugs
 ## Setup/Installation Requirements
-* Clone this repo to your machine
-* `git clone https://github.com/wikimedia/toolhunt-ui.git` 
-* `cd into toolhunt-ui`
-* `docker-compose up -d`
-*On the browser open `http://localhost:8082/`
+* Clone the Frontend repository to your machine using `git clone https://github.com/wikimedia/toolhunt-ui.git` 
+* Clone the Backend repository to your machine using `git clone https://github.com/wikimedia/toolhunt.git`
+* cd into the cloned Backend repository to build the Docker image using the Dockerfile located in the ./compose/flask/ directory. `docker build -f ./compose/flask/Dockerfile . -t toolhunt-be:dev`
+* CD to the cloned Frontend repository and run this command `docker-compose down && docker-compose up -d`
+* Insert data to the database using the instructions on the [Backend repository](https://github.com/wikimedia/toolhunt)
+* Finally, to view the Frontend page on the browser: Naviage to `http://localhost:8082/`
 ## Languages and Tools
 * Vue.js
 * HTML

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Frontend Repository for Toolhunt. Toolhunt is a web application for editing Tool
 * Clone the Frontend repository to your machine using `git clone https://github.com/wikimedia/toolhunt-ui.git` 
 * Clone the Backend repository to your machine using `git clone https://github.com/wikimedia/toolhunt.git`
 * CD into the Backend directory and follow the setup instructions in the README
-* Note: The Backend services need to be running before starting the Frontend service
+* Note: The Backend services need to be running before starting the Frontend service, failure to do this would lead to this error: `Service "toolhunt" uses an undefined network "toolhunt-net"`
 * CD to the cloned Frontend repository and run this command `docker-compose up -d`
 * Finally, to view the Frontend page on the browser: Naviage to `http://localhost:8082/`
 ## Languages and Tools

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ Frontend Repository for Toolhunt. Toolhunt is a web application for editing Tool
 ## Setup/Installation Requirements
 * Clone the Frontend repository to your machine using `git clone https://github.com/wikimedia/toolhunt-ui.git` 
 * Clone the Backend repository to your machine using `git clone https://github.com/wikimedia/toolhunt.git`
-* cd into the cloned Backend repository to build the Docker image using the Dockerfile located in the ./compose/flask/ directory. `docker build -f ./compose/flask/Dockerfile . -t toolhunt-be:dev`
-* CD to the cloned Frontend repository and run this command `docker-compose down && docker-compose up -d`
-* Insert data to the database using the instructions on the [Backend repository](https://github.com/wikimedia/toolhunt)
+* CD into the Backend directory and follow the setup instructions in the README
+* CD to the cloned Frontend repository and run this command `docker-compose up -d`
 * Finally, to view the Frontend page on the browser: Naviage to `http://localhost:8082/`
 ## Languages and Tools
 * Vue.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,35 @@
 version: "3.7"
 
 services:
+  flask-web:
+    container_name: flask-web
+    image: toolhunt-be:dev
+    ## Uncomment this line to activate bind mount volume to the backend
+    ## this would allow changes to the backend code while running the container
+    ## Note: this assumes the backend code is in a directory called "backend"
+    # volumes: 
+    #   - ../backend:/app 
+    ports:
+      - 5000:5000
+    env_file: ./.env.be.dev
+    command: /start
+    depends_on:
+      - db
+
+  db:
+    container_name: mariadb
+    image: mariadb:10.4
+    restart: always
+    environment:
+      - MARIADB_USER=user
+      - MARIADB_PASSWORD=mypassword
+      - MARIADB_ROOT_PASSWORD=rootpassword
+      - MARIADB_DATABASE=mydatabase
+    volumes:
+      - dbdata:/var/lib/mariadb/data/
+    ports:
+      - 3306:3306
+
   toolhunt:
     container_name: toolhunt
     build:
@@ -11,3 +40,6 @@ services:
       - /app/node_modules # do not bind mount node_modules
     ports:
       - "8082:8082"
+
+volumes:
+  dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,6 @@
 version: "3.7"
 
 services:
-  flask-web:
-    container_name: flask-web
-    image: toolhunt-be:dev
-    ## Uncomment this line to activate bind mount volume to the backend
-    ## this would allow changes to the backend code while running the container
-    ## Note: this assumes the backend code is in a directory called "backend"
-    # volumes: 
-    #   - ../backend:/app 
-    ports:
-      - 5000:5000
-    env_file: ./.env.be.dev
-    command: /start
-    depends_on:
-      - db
-
-  db:
-    container_name: mariadb
-    image: mariadb:10.4
-    restart: always
-    environment:
-      - MARIADB_USER=user
-      - MARIADB_PASSWORD=mypassword
-      - MARIADB_ROOT_PASSWORD=rootpassword
-      - MARIADB_DATABASE=mydatabase
-    volumes:
-      - dbdata:/var/lib/mariadb/data/
-    ports:
-      - 3306:3306
-
   toolhunt:
     container_name: toolhunt
     build:
@@ -40,6 +11,8 @@ services:
       - /app/node_modules # do not bind mount node_modules
     ports:
       - "8082:8082"
-
-volumes:
-  dbdata:
+    networks:
+      - toolhunt-net
+networks:
+  toolhunt-net:
+    external: true


### PR DESCRIPTION
As discussed on our call today. Here's a pull request setting up the backend services on the Frontends docker-compose file.

This way, anyone pulling from this repository wouldn't have to go through the process of creating a network and adding both containers manually to the said network.

I guess when we have a stable version on the BE, we can push the images to a Docker image repository(for example: DockerHub). This way people working on the Frontend could just pull the image from there rather than having to build their own images manually to setup the project.

We could also combine the Frontend and Backend projects in one repository as well and point the services to the corresponding DockerFile.

Let me know your thoughts.

**Update**:

Following @blancadesal suggestion we wouldn't need to combine all the services in the Frontend docker-compose, rather we'd rely on the network created by the BE docker-compose setup.

Depends-On: https://github.com/wikimedia/toolhunt/pull/22