### PR TITLE
Add proxy to enable viewing OpenApi docs through front-end on dev server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,10 @@ export default defineConfig({
     proxy: {
       // string shorthand: http://localhost:8082/api -> http://localhost:5000/api
       '/api': 'http://flask-web:5000',
+      '/openapi.json': {
+        target: 'http://flask-web:5000',
+        changeOrigin: true,
+      },
     }
   },
   test: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,7 @@ export default defineConfig({
     proxy: {
       // string shorthand: http://localhost:8082/api -> http://localhost:5000/api
       '/api': 'http://flask-web:5000',
+      // string shorthand: http://localhost:8082/openapi.json -> http://localhost:5000/openapi.json
       '/openapi.json': {
         target: 'http://flask-web:5000',
         changeOrigin: true,


### PR DESCRIPTION
If the BE SERVER_NAME is set to the BE container name (`flask-web`), requests to localhost:5000/ on the browser would lead to a 404. 

This proxy would allow requests to the OpenAPI documentation through the frontend port, using:
`localhost:8082/api/documentation`