### PR TITLE
Bugfix: change dateType type to String

### DIFF
--- a/src/components/table_data/DateString.vue
+++ b/src/components/table_data/DateString.vue
@@ -7,13 +7,13 @@
 <script>
 export default {
   props: {
-    dateString: Number
+    dateString: String,
   },
   computed: {
-    localeDateString: function() {
+    localeDateString: function () {
       let dateObj = new Date(this.dateString);
       return dateObj.toLocaleDateString();
-    }
-  }
-}
+    },
+  },
+};
 </script>


### PR DESCRIPTION
This fixes the `Invalid prop: type check failed for prop "dateString". ` warnings that pop up in abundance when you look at the dashboard.