### PR TITLE
Fix input_options handling

### DIFF
--- a/src/components/UserContributionForm.vue
+++ b/src/components/UserContributionForm.vue
@@ -7,7 +7,7 @@ const RE_URL_VALID_BASIC = /^https?:\/\/[^\s]+$/;
 
 const data = defineProps({
   description: String,
-  inputOptions: Object,
+  inputOptions: String,
   missingFieldName: String,
   toolName: String,
   taskId: Number,
@@ -17,10 +17,14 @@ const data = defineProps({
   pattern: String,
 });
 
-const inputOptionsArray = computed(() => {
-  return data?.inputOptions
-    ? Object.entries(data.inputOptions).map(([key, value]) => ({ key, value }))
-    : [];
+const inputOptionsArray = computed(function () {
+  if (data.inputOptions) {
+    const inputOptions = JSON.parse(data.inputOptions.replaceAll("'", '"'));
+    const inputOptionsArray = Object.entries(inputOptions).map(
+      ([key, value]) => ({ key, value })
+    );
+    return inputOptionsArray;
+  } else return [];
 });
 
 const missingFieldValue = ref(null);


### PR DESCRIPTION
Unfortunately, the limitations of MariaDB 10.1 don't allow me to store and pass input_options as a JSON value.  I tried to add a wrapper to serialization/deserialization on the backend but failed and decided that the most straightforward approach would be to embrace the string and process it on the frontend. 

This PR is related to https://github.com/wikimedia/toolhunt/pull/54/ (to test locally, you will need to be running the backend branch specified in that PR).