### PR TITLE
Define props for Leaderboard

### DIFF
--- a/src/views/LeaderboardView.vue
+++ b/src/views/LeaderboardView.vue
@@ -4,7 +4,9 @@ import LeaderboardTable from "../components/LeaderboardTable.vue";
 import { getAllTimeGreat } from "../stores/api.js";
 
 const profileBaseUrl = ref("https://meta.wikimedia.org/wiki/User:");
-
+const props = defineProps({
+  currentUser: String,
+});
 const last30DaysTopContributions = ref([]);
 const isError30Days = ref(false);
 watchEffect(async () => {


### PR DESCRIPTION
This addresses a warning about "extraneous non-props attributes" that would appear in the browser console when the Leaderboard was accessed: "currentUser" was being passed via the Vue router but not taken into use.  

The downside is that now we have an unused "props" variable in LeaderBoard.vue, but at least this error is hidden from the users.  (I have no idea which is the greater sin.)

And perhaps we could make use of this:  e.g., add something to the Leaderboard tables whereby `if userNameInThisRow == currentUser`, the row is highlighted.