### PR TITLE
Bugfix: manually set missingFieldValue to null

### DIFF
--- a/src/components/UserContributionForm.vue
+++ b/src/components/UserContributionForm.vue
@@ -75,6 +75,7 @@ const submit = async () => {
 
 function skipToNext() {
   form.value.reset();
+  missingFieldValue.value = null;
   data.getNextTask();
 }
 


### PR DESCRIPTION
This fixes an error in which missingFieldValue was occasionally acquiring a value on skipToNext()

See [T332288](https://phabricator.wikimedia.org/T332288)